### PR TITLE
fix: conditionally emit errors from muxer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/*.log
 test/repo-tests*
 **/bundle.js
+docs
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^17.0.1",
+    "aegir": "^17.1.1",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.6.0",
     "libp2p-tcp": "~0.13.0",
     "libp2p-websockets": "~0.12.0",
-    "multiaddr": "^5.0.0",
+    "multiaddr": "^6.0.0",
     "pull-file": "^1.1.0",
     "pull-pair": "^1.1.0",
     "run-parallel": "^1.1.9",
@@ -55,7 +55,8 @@
     "tape": "^4.9.0"
   },
   "dependencies": {
-    "interface-connection": "~0.3.2",
+    "debug": "^4.1.0",
+    "interface-connection": "~0.3.3",
     "pull-catch": "^1.0.0",
     "pull-stream": "^3.6.9",
     "pull-stream-to-stream": "^1.3.4",

--- a/src/muxer.js
+++ b/src/muxer.js
@@ -6,6 +6,9 @@ const toPull = require('stream-to-pull-stream')
 const pullCatch = require('pull-catch')
 const pull = require('pull-stream')
 const noop = () => {}
+const debug = require('debug')
+const log = debug('spdy')
+log.error = debug('spdy:error')
 
 function catchError (stream) {
   return {
@@ -55,6 +58,22 @@ module.exports = class Muxer extends EventEmitter {
       )
       this.emit('stream', muxedConn)
     })
+  }
+
+  /**
+   * Conditionally emit errors if we have listeners. All other
+   * events are sent to EventEmitter.emit
+   *
+   * @param {string} eventName
+   * @param  {...any} args
+   * @returns {void}
+   */
+  emit (eventName, ...args) {
+    if (eventName === 'error' && !this._events.error) {
+      log.error('error', ...args)
+    } else {
+      super.emit(eventName, ...args)
+    }
   }
 
   // method added to enable pure stream muxer feeling

--- a/test/muxer.spec.js
+++ b/test/muxer.spec.js
@@ -100,4 +100,12 @@ describe('multiplex-muxer', () => {
       code: 'ERR_UNKNOWN'
     }))
   })
+
+  it('should not throw if there are no error listeners', () => {
+    muxer.removeAllListeners('error')
+
+    muxer.spdy.emit('error', Object.assign(new Error('bad things'), {
+      code: 'ERR_UNKNOWN'
+    }))
+  })
 })


### PR DESCRIPTION
This will emit errors from muxer if there are listeners for the events. This will prevent uncaught exceptions if there are no listeners. Since errors will cause streams to close, there's no need to mandate having listeners.

Related to https://github.com/libp2p/js-libp2p-floodsub/pull/63#issuecomment-443732951