### PR TITLE
fix: handle error on .end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: node_js
+cache: npm
+stages:
+  - check
+  - test
+  - cov
+
+node_js:
+  - '10'
+
+os:
+  - linux
+  - osx
+
+script: npx nyc -s npm run test:node -- --bail
+after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
+
+jobs:
+  include:
+    - os: windows
+      cache: false
+
+    - stage: check
+      script:
+        - npx aegir commitlint --travis
+        - npx aegir dep-check
+        - npm run lint
+
+    - stage: test
+      name: chrome
+      addons:
+        chrome: stable
+      script: npx aegir test -t browser -t webworker
+
+    - stage: test
+      name: firefox
+      addons:
+        firefox: latest
+      script: npx aegir test -t browser -t webworker -- --browsers FirefoxHeadless
+
+notifications:
+  email: false

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,0 @@
-// Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()

--- a/package.json
+++ b/package.json
@@ -39,25 +39,26 @@
     "npm": ">=3.0.0"
   },
   "devDependencies": {
-    "aegir": "^17.1.1",
+    "aegir": "^18.2.1",
     "chai": "^4.2.0",
     "chai-checkmark": "^1.0.1",
     "dirty-chai": "^2.0.1",
     "interface-stream-muxer": "~0.6.0",
     "libp2p-tcp": "~0.13.0",
-    "libp2p-websockets": "~0.12.0",
-    "multiaddr": "^6.0.0",
+    "libp2p-websockets": "~0.12.2",
+    "multiaddr": "^6.0.6",
     "pull-file": "^1.1.0",
     "pull-pair": "^1.1.0",
     "run-parallel": "^1.1.9",
-    "sinon": "^7.1.0",
+    "sinon": "^7.2.7",
     "tap-spec": "^4.1.1",
-    "tape": "^4.9.0"
+    "tape": "^4.10.1"
   },
   "dependencies": {
-    "debug": "^4.1.0",
+    "debug": "^4.1.1",
     "interface-connection": "~0.3.3",
-    "pull-catch": "^1.0.0",
+    "once": "^1.4.0",
+    "pull-catch": "^1.0.1",
     "pull-stream": "^3.6.9",
     "pull-stream-to-stream": "^1.3.4",
     "spdy-transport": "^3.0.0",

--- a/src/muxer.js
+++ b/src/muxer.js
@@ -5,6 +5,7 @@ const Connection = require('interface-connection').Connection
 const toPull = require('stream-to-pull-stream')
 const pullCatch = require('pull-catch')
 const pull = require('pull-stream')
+const once = require('once')
 const noop = () => {}
 const debug = require('debug')
 const log = debug('spdy')
@@ -102,7 +103,10 @@ module.exports = class Muxer extends EventEmitter {
   }
 
   end (cb) {
-    cb = cb || noop
+    cb = once(cb || noop)
+    this.spdy.once('error', (err) => {
+      cb(err)
+    })
     this.spdy.end((err) => {
       if (err && /ok/i.test(err.message)) {
         return cb()


### PR DESCRIPTION
* also use travis

There is currently a bug in spdy-transport where during an `end` request, if spdy errors, it doesn't emit a closed event. This may occur when the connection has already ended and a write is attempted.  This adds an `error` listener during `.end` to work around this issue.

