### PR TITLE
fix: destroy streams on end

### DIFF
--- a/src/muxer.js
+++ b/src/muxer.js
@@ -39,7 +39,6 @@ module.exports = class Muxer extends EventEmitter {
       if (didError && /ok/i.test(didError.message)) {
         didError = false
       }
-      spdy.destroyStreams(new Error('underlying socket has been closed'))
       this.emit('close', didError)
     })
 
@@ -103,10 +102,9 @@ module.exports = class Muxer extends EventEmitter {
   }
 
   end (cb) {
-    cb = once(cb || noop)
-    this.spdy.once('error', (err) => {
-      cb(err)
-    })
+    cb = cb ? once(cb) : noop
+    this.spdy.once('error', cb)
+    this.spdy.destroyStreams()
     this.spdy.end((err) => {
       if (err && /ok/i.test(err.message)) {
         return cb()


### PR DESCRIPTION
This is a work around to prevent `.end` from stalling. If there are open streams on the muxer that spdy-transport doesn not issues go away for, these streams can prevent the muxer from closing. This change will preemptively destroy the streams to get around this issue.

spdy-transport also destroys streams when it closes, so we don't need to do that in our close listener. 

Required by https://github.com/libp2p/js-libp2p-switch/pull/313